### PR TITLE
Notify the teleport service to restart when the binary changes

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -21,7 +21,8 @@ class teleport::install {
       target => "${teleport::extract_path}/teleport/tctl";
     "${teleport::bin_dir}/teleport":
       ensure => link,
-      target => "${teleport::extract_path}/teleport/teleport";
+      target => "${teleport::extract_path}/teleport/teleport",
+      notify => Service['teleport'];
     "${teleport::bin_dir}/tsh":
       ensure => link,
       target => "${teleport::extract_path}/teleport/tsh";


### PR DESCRIPTION
When there's a version update, the archive correctly downloads the new release and untars it, but the service is never restarted, this fixes that issue.